### PR TITLE
[UX] Safari : correctly show the placeholders on safari PATH=/compte

### DIFF
--- a/src/components/pages/account.tsx
+++ b/src/components/pages/account.tsx
@@ -23,7 +23,7 @@ const inputStyle: React.CSSProperties = {
   fontFamily: 'ProximaSoft',
   fontSize: 16,
   height: 24,
-  lineHeight: 24,
+  lineHeight: '24px',
   marginTop: 20,
   padding: '18px 25px',
   width: 'calc(100% - 52px)',


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/ma-voie-internal/544)
<!-- Reviewable:end -->
