### PR TITLE
Reduce padding on the info at the bottom of partner card so that it can fit long partner names.

### DIFF
--- a/src/components/partner_card.tsx
+++ b/src/components/partner_card.tsx
@@ -58,7 +58,7 @@ const infoStyle: React.CSSProperties = {
   color: '#fff',
   fontWeight: 'bold',
   left: 0,
-  padding: '12px 60px',
+  padding: '12px 15px',
   position: 'absolute',
   right: 0,
   textAlign: 'center',


### PR DESCRIPTION
Fix #637

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/ma-voie/640)
<!-- Reviewable:end -->
