### PR TITLE
[Fix] Do not block account update after signup.

### DIFF
--- a/src/components/pages/account.tsx
+++ b/src/components/pages/account.tsx
@@ -149,7 +149,7 @@ const AccountPage = (): React.ReactElement => {
       age: !inputAge,
       diploma: !inputDiploma,
       email: !inputEmail || !isEmailValid,
-      inputLegals: !inputLegals,
+      ...isConnected ? {} : {inputLegals: !inputLegals},
       lastName: !inputLastName,
       name: !inputName,
       password: !password && !userId,
@@ -172,7 +172,7 @@ const AccountPage = (): React.ReactElement => {
       ...inputJobSeeker ? {jobSeeker: true} : {jobSeeker: false},
       ...inputRetraining ? {retraining: true} : {retraining: false},
       ...utmSource ? {source: utmSource} : {},
-      areLegalMentionsAccepted: inputLegals,
+      ...(!isConnected || !areLegalMentionsAccepted) ? {areLegalMentionsAccepted: inputLegals} : {},
     }
     if (Object.keys(update).length) {
       // TODO(émilie): Move to actions.ts
@@ -192,7 +192,7 @@ const AccountPage = (): React.ReactElement => {
     }
   }, [age, diploma, email, firebase, firestore, name, inputAge, inputDiploma, inputEmail,
     inputJobSeeker, inputLegals, inputName, lastName, inputLastName, inputPhone, inputRetraining,
-    password, phone, setErrorMessage, t, userId])
+    password, phone, setErrorMessage, t, userId, isConnected, areLegalMentionsAccepted])
   useFastForward(() => {
     if (inputName && inputLastName && inputEmail && inputPhone && password && inputDiploma) {
       onSave()

--- a/test/node/translation_test.ts
+++ b/test/node/translation_test.ts
@@ -2,7 +2,7 @@ const {expect} = require('chai')
 const glob = require('glob')
 const path = require('path')
 require('json5/lib/register')
-const babelExtractConfig = require('../../i18n.babelrc.js')
+const babelExtractConfig = require('../../i18n.babelrc')
 
 const extractedLangs: ReadonlySet<string> = new Set(babelExtractConfig.plugins.
   find((plugin: unknown[]) => plugin[0] === 'i18next-extract')[1].locales)


### PR DESCRIPTION
To reproduce: Create an account, then disconnect and try to reconnect, after the connexion there is a redirection to the account and it's impossible to validate the process because the legals are not shown to connected users who already have an account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/ma-voie/659)
<!-- Reviewable:end -->
