### PR TITLE
[Flow] Allow people who chose a partner to go back to the other pages of this step.

### DIFF
--- a/src/components/pages/definition/index.tsx
+++ b/src/components/pages/definition/index.tsx
@@ -19,8 +19,6 @@ const DefinitionPage = (): React.ReactElement => {
   const {definition: {completed = false, selectedPartnerId = null} = {}} = useCertifiedSteps()
   // i18next-extract-mark-ns-start url
   return <Switch>
-    {selectedPartnerId && !completed ?
-      <Redirect to={defineAndGetPath('PARTNERS_INTERNAL')} /> : null}
     {selectedPartnerId && completed ? <Redirect to={getPath(['STEPS'], t)} /> : null}
     <Route path={defineAndGetPath('EXPERIENCE')} component={ExperiencePage} />
     <Route path={defineAndGetPath('GO')} component={GoPage} />

--- a/src/components/pages/skills/index.tsx
+++ b/src/components/pages/skills/index.tsx
@@ -15,8 +15,6 @@ const SkillsPage = (): React.ReactElement => {
   const {skills: {completed = false, selectedPartnerId = null} = {}} = useCertifiedSteps()
   // i18next-extract-mark-ns-start url
   return <Switch>
-    {selectedPartnerId && !completed ?
-      <Redirect to={defineAndGetPath('PARTNERS_INTERNAL')} /> : null}
     {selectedPartnerId && completed ? <Redirect to={getPath(['STEPS'], t)} /> : null}
     <Route path={defineAndGetPath('GO')} component={GoPage} />
     <Route path={defineAndGetPath('LIST')} component={ListPage} />

--- a/src/components/pages/training/index.tsx
+++ b/src/components/pages/training/index.tsx
@@ -13,8 +13,6 @@ const TrainingPage = (): React.ReactElement => {
   const {training: {completed = false, selectedPartnerId = null} = {}} = useCertifiedSteps()
   // i18next-extract-mark-ns-start url
   return <Switch>
-    {selectedPartnerId && !completed ?
-      <Redirect to={defineAndGetPath('PARTNERS_INTERNAL')} /> : null}
     {selectedPartnerId && completed ? <Redirect to={getPath(['STEPS'], t)} /> : null}
     <Route path={defineAndGetPath('WHICH')} component={WhichPage} />
     <Redirect to={defineAndGetPath('WHICH')} />


### PR DESCRIPTION
To reproduce the bug: go to the definition step, ask for a training, and click on a partner. Then, try to go back => You won't be able to return to the <what is your project?> question. This fix allows this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/ma-voie/673)
<!-- Reviewable:end -->
